### PR TITLE
Fixed packages requirements and version issues.

### DIFF
--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -6,10 +6,10 @@ tensorflow==1.15.2
 scikit-image==0.13.1
 scikit-learn==0.19.1
 numpy==1.15.1
-moviepy==0.2.3.5
+moviepy==1.0.0
 requests==2.18.4
 keras==2.0.9
 python-dotenv==0.7.1
 tensorboardX==1.4
-pretrainedmodels==0.7.4
 torch==0.4.1
+torchvision==0.2.1


### PR DESCRIPTION
1. `moviepy==0.2.3.5` caused
```
    Traceback (most recent call last):
    File "inference.py", line 3, in <module>
        import moviepy.editor as mov_editor
    File "/home/kartikey/anaconda3/envs/celeb_env/lib/python3.6/site-packages/moviepy/editor.py", line 26, in <module>
        imageio.plugins.ffmpeg.download()
    File "/home/kartikey/anaconda3/envs/celeb_env/lib/python3.6/site-packages/imageio/plugins/ffmpeg.py", line 38, in download
        "imageio.ffmpeg.download() has been deprecated. "
    RuntimeError: imageio.ffmpeg.download() has been deprecated. Use 'pip install imageio-ffmpeg' instead.
```
which could be fixed by upgrading to `moviepy==1.0.0`.

2. Another error - `ImportError: cannot import name 'Optional'`
could be solved by not installing `pretrainedmodels==0.7.4` as it was installing `torchvision==0.6.0` which caused the problem but `torchvision==0.2.1` worked.

   